### PR TITLE
Minor polishing + Fix message glitch

### DIFF
--- a/ecyp-database.Rmd
+++ b/ecyp-database.Rmd
@@ -12,7 +12,7 @@ resource_files:
 ---
 
 ```{r}
-# Purpose of this Rmd is to host a Shint app that allows alumni to use their unique ID to access their information in the
+# Purpose of this Rmd is to host a Shiny app that allows alumni to use their unique ID to access their information in the
 # Alumni spreadsheet and be able to update that information
 ```
 
@@ -150,18 +150,22 @@ output$UI <- renderUI({
   ecyp_db <- refresh_table(sheet_url)
 
   variable_list <- c("---", setdiff(names(ecyp_db), c("Unique_Number", "Last_Updated")))
-  names(variable_list) <- c("---", setdiff(names(ecyp_db), c("Unique_Number", "Last_Updated")))
+  names(variable_list) <- variable_list
 
   basicPage(
     # Have the user specify their ID number
-    textInput("enter_number", label = h4("Enter your number"), value = NULL),
+    textInput("enter_number", 
+              label = h4("Enter your number"), 
+              value = NULL),
     # Have the user choose what variable from the table they want to change
     selectInput("variable",
       label = h4("Choose which field to update:"),
       choices = variable_list,
       selected = "---"
     ),
-    textInput("new_value", label = h4("Enter the new value for this variable:"), value = NULL),
+    textInput("new_value", 
+              label = h4("Enter the new value for this variable:"), 
+              value = NULL),
     actionButton("submit", "Update Info", icon("fas fa-sync"))
   )
 })
@@ -203,12 +207,6 @@ ecyp_update <- reactive({
   }
 })
 
-renderUI({
-  if (!is.null(input$submit)) {
-    tableOutput("ecyp_table")
-  }
-})
-
 DT::DTOutput("table")
 
 # Load the reactive values into data table
@@ -230,7 +228,7 @@ observeEvent(input$submit, {
       ecyp_db <- refresh_table(sheet_url)
 
       variable_list <- c("---", setdiff(names(ecyp_db), c("Unique_Number", "Last_Updated")))
-      names(variable_list) <- c("---", setdiff(names(ecyp_db), c("Unique_Number", "Last_Updated")))
+      names(variable_list) <- variable_list
       basicPage(
         # Have the user specify their ID number
         textInput("enter_number", label = h4("Enter your number"), value = input$enter_number),

--- a/ecyp-database.Rmd
+++ b/ecyp-database.Rmd
@@ -145,6 +145,7 @@ uiOutput("UI")
 
 # Have the user write in the new value and click submit when they are done
 output$UI <- renderUI({
+  shinyjs::useShinyjs()
   sheet_url <- "https://docs.google.com/spreadsheets/d/1rQaqQIYLZw1tZnJZQHMNhTf0-zDRH2zWzA6Eo0giP80/edit#gid=1665986408"
 
   ecyp_db <- refresh_table(sheet_url)
@@ -198,8 +199,6 @@ ecyp_update <- reactive({
 
     refresh_table(sheet_url) %>%
       dplyr::filter(Unique_Number == enter_number())
-
-    shinyjs::reset("sidebar")
   }
   if (!is.null(enter_number())) {
     refresh_table(sheet_url) %>%
@@ -220,10 +219,13 @@ output$table <- DT::renderDataTable({
 # If a new value is given, we want to put write it in the main googlesheet underneath the given variable name
 observeEvent(input$submit, {
   if (!is.null(input$submit) && input$submit > 0) {
+    shinyjs::reset("submit")
     output$table <- DT::renderDT({
       ecyp_update()
     })
+    variable_changed <- input$variable
     output$UI <- renderUI({
+      shinyjs::useShinyjs()
       sheet_url <- "https://docs.google.com/spreadsheets/d/1rQaqQIYLZw1tZnJZQHMNhTf0-zDRH2zWzA6Eo0giP80/edit#gid=1665986408"
       ecyp_db <- refresh_table(sheet_url)
 
@@ -236,11 +238,11 @@ observeEvent(input$submit, {
         selectInput("variable",
           label = h4("Choose which field to update:"),
           choices = variable_list,
-          selected = input$variable
+          selected = NULL
         ),
         textInput("new_value", label = h4("Enter the new value for this variable:"), value = NULL),
         actionButton("submit", "Update Info", icon("fas fa-sync")),
-        h4(paste0("'", input$variable, "'", " was updated."))
+        h4(paste0("'", variable_changed, "'", " was updated."))
       )
     })
   }


### PR DESCRIPTION
The "variable has been updated" message goes off if you have submitted one field and then choose a second field (before you hit submit) It doesn't actually mess with the data, but it does print off the message which is confusing to the user. 

I think the key might be to make sure that the variables are more explicitly reset after the function that runs after `input$submit` has been run. 

I think `shinyjs::reset()` might be what we want. 